### PR TITLE
Show version information about the various decompilers

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -60,6 +60,7 @@ RUN echo "${GHIDRA_SHA256}  $(basename ${GHIDRA_URL})" | sha256sum -c - \
  && mv /opt/ghidra/* /tmp/ghidra \
  && mv /tmp/ghidra/* /opt/ghidra
 COPY ghidra/dump.py /opt/ghidra/dump.py
+COPY ghidra/version.py /opt/ghidra/version.py
 
 COPY common/mdec-base /mdec-base
 COPY ghidra/mdec-ghidra /mdec-ghidra
@@ -80,6 +81,7 @@ COPY ida/private/ida_latest.tar.bz2 .
 RUN tar xf ida_latest.tar.bz2 && rm ida_latest.tar.bz2
 RUN /opt/ida/install_dependencies_64bit.sh
 COPY ida/decompile_all.py .
+COPY ida/version.py .
 
 WORKDIR /root
 COPY ida/private/license_stuff.tgz .

--- a/backend/angr/mdec-angr/mdecangr/service.py
+++ b/backend/angr/mdec-angr/mdecangr/service.py
@@ -38,3 +38,6 @@ class AngrService(Service):
                 out.append('/* Decompilation of %s failed:\n%s\n*/' % (func, traceback.format_exc()))
 
         return '\n'.join(out)
+
+    def version(self) -> str:
+        return '.'.join(str(i) for i in angr.__version__)

--- a/backend/binja/mdec-binja/mdecbinja/service.py
+++ b/backend/binja/mdec-binja/mdecbinja/service.py
@@ -32,3 +32,6 @@ class BinjaService(Service):
             for line in (first + last):
                 out.append(str(line))
         return '\n'.join(out)
+
+    def version(self) -> str:
+        return core_version()

--- a/backend/common/mdec-base/mdecbase/service.py
+++ b/backend/common/mdec-base/mdecbase/service.py
@@ -14,8 +14,12 @@ class Service:
     def __init__(self):
         self.app = web.Application()
         self.app.add_routes([web.post('/decompile', self.post_decompile)])
+        self.app.add_routes([web.get('/version', self.get_version)])
 
     def decompile(self, path: str) -> str:
+        raise NotImplementedError()
+
+    def version(self) -> str:
         raise NotImplementedError()
 
     async def post_decompile(self, request: aiohttp.web.BaseRequest) -> web.Response:
@@ -40,6 +44,15 @@ class Service:
                 resp_status = 500
 
             return web.Response(text=decomp, status=resp_status)
+
+    async def get_version(self, request: aiohttp.web.BaseRequest) -> web.Response:
+        try:
+            version = self.version()
+            resp_status = 200
+        except:
+            version = traceback.format_exc()
+            resp_status = 500
+        return web.Response(text=version, status=resp_status)
 
 
 def mdec_main(service: Service):

--- a/backend/ghidra/mdec-ghidra/mdecghidra/service.py
+++ b/backend/ghidra/mdec-ghidra/mdecghidra/service.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+import tempfile
 
 from mdecbase import Service
 
@@ -22,3 +23,15 @@ class GhidraService(Service):
         finally:
             os.chdir(original_cwd)
         return code
+
+    def version(self) -> str:
+        original_cwd = os.getcwd()
+        version = ''
+        try:
+            with tempfile.TemporaryDirectory() as tmp:
+                os.chdir(tmp)
+                subprocess.run(['/opt/ghidra/support/pythonRun', '/opt/ghidra/version.py'])
+                version = open('version.txt').read()
+        finally:
+            os.chdir(original_cwd)
+        return version

--- a/backend/ghidra/version.py
+++ b/backend/ghidra/version.py
@@ -1,0 +1,6 @@
+from ghidra.framework import Application
+import traceback
+
+out = open('version.txt', 'w')
+out.write(Application.getApplicationVersion() + ' ' +
+          Application.getApplicationReleaseName() + '\n')

--- a/backend/ida/mdec-ida/mdecida/service.py
+++ b/backend/ida/mdec-ida/mdecida/service.py
@@ -1,6 +1,8 @@
 import os
 import subprocess
+import tempfile
 
+from pathlib import Path
 from mdecbase import Service
 
 
@@ -20,3 +22,18 @@ class IdaService(Service):
             return open(outpath).read()
         except:
             print(open(logpath).read())
+
+    def version(self) -> str:
+        logpath = os.path.join(os.getcwd(), 'ida.log')
+
+        # TODO: Is there a way to do this without creating an idb?
+        with tempfile.TemporaryDirectory() as tmp:
+            dummy_path = Path(tmp) / 'dummy'
+            with open(dummy_path, 'wb') as dummy_file:
+                dummy_file.write(b'\x00' * 256)
+                subprocess.run(['/opt/ida/idat64', '-A', '-a',
+                                '-S/opt/ida/version.py', '-L'+logpath, str(dummy_path)])
+            try:
+                return open(dummy_path.parent / 'version.txt').read().strip()
+            except:
+                print(open(logpath).read())

--- a/backend/ida/version.py
+++ b/backend/ida/version.py
@@ -1,0 +1,49 @@
+from __future__ import print_function
+
+import ida_ida
+import ida_auto
+import ida_loader
+import ida_hexrays
+import ida_idp
+import ida_entry
+import idautils
+import os.path
+
+# becsause the -S script runs very early, we need to load the decompiler
+# manually if we want to use it
+def init_hexrays():
+    ALL_DECOMPILERS = {
+        ida_idp.PLFM_386: "hexrays",
+        ida_idp.PLFM_ARM: "hexarm",
+        ida_idp.PLFM_PPC: "hexppc",
+        ida_idp.PLFM_MIPS: "hexmips",
+    }
+    cpu = ida_idp.ph.id
+    decompiler = ALL_DECOMPILERS.get(cpu, None)
+    if not decompiler:
+        print("No known decompilers for architecture with ID: %d" % ida_idp.ph.id)
+        return False
+    if ida_ida.inf_is_64bit():
+        if cpu == ida_idp.PLFM_386:
+            decompiler = "hexx64"
+        else:
+            decompiler += "64"
+    if ida_loader.load_plugin(decompiler) and ida_hexrays.init_hexrays_plugin():
+        return True
+    else:
+        print('Couldn\'t load or initialize decompiler: "%s"' % decompiler)
+        return False
+
+
+def main():
+    idbpath = idc.get_idb_path()
+    cpath = os.path.join(os.path.dirname(idbpath), "version.txt")
+    with open(cpath, "w") as outfile:
+        if init_hexrays():
+            outfile.write(ida_hexrays.get_hexrays_version())
+        else:
+            outfile.write(str(ida_ida.inf_get_version() / 100))
+    ida_pro.qexit(0)
+
+
+main()

--- a/backend/reko/mdec-reko/mdecreko/service.py
+++ b/backend/reko/mdec-reko/mdecreko/service.py
@@ -17,3 +17,10 @@ class RekoService(Service):
         reko_dir = path + '.reko'
         source_path = os.path.join(reko_dir, os.path.basename(path) + '_text.c')
         return open(source_path).read()
+
+    def version(self) -> str:
+        output = subprocess.check_output(['/opt/reko/decompile', '--version']).decode('utf-8')
+        # 'Decompile.exe version 0.10.1.0 (git:426370b)\n'
+        version_line = output.strip()
+        assert version_line.startswith('Decompile.exe version ')
+        return version_line.split(' ')[2].strip()

--- a/backend/retdec/mdec-retdec/mdecretdec/service.py
+++ b/backend/retdec/mdec-retdec/mdecretdec/service.py
@@ -15,3 +15,13 @@ class RetdecService(Service):
         """
         subprocess.check_output(['/opt/retdec/bin/retdec-decompiler', path]).decode('utf-8')
         return open(path + '.c').read()
+
+    def version(self) -> str:
+        output = subprocess.check_output(['/opt/retdec/bin/retdec', '--version']).decode('utf-8')
+        lines = output.split('\n')
+        version_lines = [l for l in lines if l.startswith('RetDec version')]
+        assert len(version_lines) > 0
+        # 'RetDec version :  v4.0-414-gc990727e'
+        version_line = version_lines[0].strip()
+        assert version_line.startswith('RetDec version :  ')
+        return version_line.split(':')[1].strip()

--- a/backend/snowman/mdec-snowman/mdecsnowman/service.py
+++ b/backend/snowman/mdec-snowman/mdecsnowman/service.py
@@ -14,3 +14,14 @@ class SnowmanService(Service):
         Decompile all the functions in the binary located at `path`.
         """
         return subprocess.check_output(['/opt/snowman/bin/nocode', path]).decode('utf-8')
+
+    def version(self) -> str:
+        # There is no --version, but there is version information in --help (commit hash only?)
+        proc = subprocess.Popen(
+            ['/opt/snowman/bin/nocode', '--help'], stdout=subprocess.PIPE)
+        (stdout, stderr) = proc.communicate()
+        lines = stdout.decode('utf-8').split('\n')
+        version_lines = [l for l in lines if l.startswith("Version: ")]
+        assert len(version_lines) > 0
+        version_line = version_lines[0].strip()
+        return version_line.split(':')[1].strip()

--- a/frontend/www/index.html
+++ b/frontend/www/index.html
@@ -67,6 +67,12 @@ body {
   font-size: 1em;
 }
 
+.editor-col .version {
+  white-space: pre-wrap;
+  font-size: 0.75em;
+  text-align: center;
+}
+
 .editor {
   flex: 1;
 }
@@ -140,13 +146,13 @@ body {
   <div class="mrow content">
 
   <div class="editor-row">
-    <div class="editor-col" id="angr-col"><h3>angr</h3><div class="editor" id="angr-editor"></div></div>
-    <div class="editor-col" id="binja-col"><h3>Binary Ninja</h3><div class="editor" id="binja-editor"></div></div>
-    <div class="editor-col" id="ghidra-col"><h3>Ghidra</h3><div class="editor" id="ghidra-editor"></div></div>
-    <div class="editor-col" id="ida-col"><h3>IDA</h3><div class="editor" id="ida-editor"></div></div>
-    <div class="editor-col" id="reko-col"><h3>Reko</h3><div class="editor" id="reko-editor"></div></div>
-    <div class="editor-col" id="retdec-col"><h3>RetDec</h3><div class="editor" id="retdec-editor"></div></div>
-    <div class="editor-col" id="snowman-col"><h3>Snowman</h3><div class="editor" id="snowman-editor"></div></div>
+    <div class="editor-col" id="angr-col"><h3>angr</h3><div class="version" id="angr-version"></div><div class="editor" id="angr-editor"></div></div>
+    <div class="editor-col" id="binja-col"><h3>Binary Ninja</h3><div class="version" id="binja-version"></div><div class="editor" id="binja-editor"></div></div>
+    <div class="editor-col" id="ghidra-col"><h3>Ghidra</h3><div class="version" id="ghidra-version"></div><div class="editor" id="ghidra-editor"></div></div>
+    <div class="editor-col" id="ida-col"><h3>IDA</h3><div class="version" id="ida-version"></div><div class="editor" id="ida-editor"></div></div>
+    <div class="editor-col" id="reko-col"><h3>Reko</h3><div class="version" id="reko-version"></div><div class="editor" id="reko-editor"></div></div>
+    <div class="editor-col" id="retdec-col"><h3>RetDec</h3><div class="version" id="retdec-version"></div><div class="editor" id="retdec-editor"></div></div>
+    <div class="editor-col" id="snowman-col"><h3>Snowman</h3><div class="version" id="snowman-version"></div><div class="editor" id="snowman-editor"></div></div>
   </div>
 
   </div>
@@ -162,6 +168,7 @@ body {
 
     var services = ['angr', 'binja', 'ghidra', 'ida', 'reko', 'retdec', 'snowman'];
     var editors = {};
+    var version_boxes = {};
     var options = [];
 
     function update_window_title() {
@@ -178,6 +185,13 @@ body {
       var file = $('#file')[0].files[0];
       if (file == undefined) return;
       fd.append('file', file);
+      $.ajax({
+          url: '/'+svc+'/version',
+          type: 'get',
+          success: function(response){
+            version_boxes[svc].text(response);
+          }
+      })
       $.ajax({
           url: '/'+svc+'/decompile',
           type: 'post',
@@ -229,6 +243,7 @@ body {
       editor.setFontSize(18);
       editor.session.setMode("ace/mode/c_cpp");
       editors[svc] = editor;
+      version_boxes[svc] = $('#' + svc + "-version");
     }
 
     $(document).ready(function() {


### PR DESCRIPTION
Closes #10. Everything but IDA works as tested on my local machine (macOS w/ docker) and IDA ... worked in python on a machine with a Windows copy. Will need testing IDA for linux on a linux machine, which I don't have readily available.

Current implementation is handled by a route in each of the containers, using (hopefully) a reliable version source. Versions are loaded via ajax and displayed under the decompiler names like this:
<img width="1534" alt="image" src="https://user-images.githubusercontent.com/711973/158039987-ead8284c-68fb-40bf-a788-0f0b3b1dd293.png">
